### PR TITLE
Security: Patch reachable underscore vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "node-esapi": "0.0.1",
         "serve-favicon": "^2.3.0",
         "swig": "^1.4.2",
-        "underscore": "^1.8.3"
+        "underscore": "^1.13.8"
       },
       "devDependencies": {
         "async": "^2.0.0-rc.4",
@@ -7984,7 +7984,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -8012,19 +8012,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8033,7 +8033,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -8045,7 +8045,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -14443,9 +14443,10 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/underscore.string": {
       "version": "3.3.5",
@@ -21682,7 +21683,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -21708,17 +21709,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -21726,7 +21727,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -21736,7 +21737,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -26768,9 +26769,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
     },
     "underscore.string": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node-esapi": "0.0.1",
     "serve-favicon": "^2.3.0",
     "swig": "^1.4.2",
-    "underscore": "^1.8.3"
+    "underscore": "^1.13.8"
   },
   "comments": {
     "//": "a9 insecure components"


### PR DESCRIPTION
## Security Sentinel — Reachable vulnerability patch

Automated patch by Oz Sentinel (fast local mode).

### Trivy summary
- **HIGH/CRITICAL findings:** 43 (across 20 unique packages)
- **Reachable from production code:** 4 vulnerabilities across 3 packages
- **Patched in this PR:** 2 vulnerabilities (1 package — `underscore`)
- **Triaged as Unreachable:** 39 (transitive devDeps in `node_modules` not imported by `server.js`, `config/`, or `app/`)
- **No upstream fix available:** 2 (`swig@1.4.2`, package unmaintained — see notes)

### Reachable & patched
| Package | CVE | Severity | From | To |
| --- | --- | --- | --- | --- |
| underscore | CVE-2021-23358 | CRITICAL | 1.9.1 | 1.13.8 |
| underscore | CVE-2026-27601 | HIGH | 1.9.1 | 1.13.8 |

Reachability evidence: `config/config.js:1` calls `require("underscore")`.

### Reachable, no upstream fix
| Package | CVE | Severity | Notes |
| --- | --- | --- | --- |
| swig | CVE-2023-25345 | HIGH | `swig@1.4.2` is unmaintained; no fixed version. Tracked separately — recommend migrating to `swig-templates` or another templating engine. |

### Unreachable triage (sample)
`braces`, `debug`, `decode-uri-component`, `fsevents`, `i`, `ini`, `kind-of`, `minimatch`, `minimist`, `mixin-deep`, `nconf`, `path-to-regexp`, `qs`, `semver`, `set-value`, `tar`, `y18n` — none of these are `require()`'d from `server.js`, `config/`, or `app/**`. They appear only as transitive dependencies of dev tooling (grunt, cypress, nodemon).

`body-parser` flagged as 1.18.3 by Trivy, but `package-lock.json` resolves it to **2.2.2** (already past the fix in 1.20.3). No action required.

### Validation
- `npm test` → passes (mochaTest:unit, no failing files).

_Conversation: https://app.warp.dev/conversation/5ff87f5c-d1af-480b-84e1-7e5db05bd9b0_
_Run: https://oz.warp.dev/runs/019dcf83-58d1-7ca8-9b13-db966eab2ddf_

_This PR was generated with [Oz](https://warp.dev/oz)._
